### PR TITLE
Integrate ESLint and Prettier for Code Linting and Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,38 +9,39 @@
 </div>
 
 ## 功能
+
 可將學校課表匯入通用日曆軟體！
 
 ![alt text](/imgs/image-5.png)
 
 ## 其他
+
 - 有任何問題可以聯絡我！
 - 歡迎推 pr！
-
 
 ## 使用教學
 
 ### [！按我使用！](https://ntust-calendar-maker.zudo.cc)
 
 - 填入開學日期以及結業日期
-    - 112-2 開學日 02/19 | 結業日 06/10
-    - 113-1 開學日 09/02 | 結業日 12/20
+  - 112-2 開學日 02/19 | 結業日 06/10
+  - 113-1 開學日 09/02 | 結業日 12/20
     ![alt text](/imgs/image.png)
 - 至選課系統下載課程資料 `.html` 檔
-    - 右鍵儲存
+  - 右鍵儲存
     ![alt text](/imgs/image-1.png)
-    - 可將格式更改為 html only
+  - 可將格式更改為 html only
     ![alt text](/imgs/image-2.png)
 - 上傳檔案後生成 `.ics` 檔案
-    - 按下上傳
+  - 按下上傳
     ![alt text](/imgs/image-3.png)
-    - 選擇剛剛下載的檔案
+  - 選擇剛剛下載的檔案
     ![alt text](/imgs/image-4.png)
-    - 下載日曆檔案
+  - 下載日曆檔案
     ![alt text](/imgs/image-8.png)
 - 匯入通用通用日曆軟體 (e.g. Google Calendar)
-    - 按設定
+  - 按設定
     ![alt text](/imgs/image-6.png)
-    - 選擇檔案並匯入指定日曆
+  - 選擇檔案並匯入指定日曆
     ![alt text](/imgs/image-7.png)
 - 完成！

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,11 @@
+import globals from "globals";
+import pluginJs from "@eslint/js";
+import pluginVue from "eslint-plugin-vue";
+
+/** @type {import('eslint').Linter.Config[]} */
+export default [
+  { files: ["**/*.{js,mjs,cjs,vue}"] },
+  { languageOptions: { globals: globals.browser } },
+  pluginJs.configs.recommended,
+  ...pluginVue.configs["flat/essential"],
+];

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <!--
 程式出Bug了？
  　　　∩∩
@@ -24,15 +24,31 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/src/assets/ntust_so_hard.png" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="/src/assets/ntust_so_hard.png"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>NTUST Calendar Maker</title>
-    <meta property="og:image" content="/src/assets/ntust_so_hard.png"> 
-    <meta name="theme-color" content="#d15dcb"> 
-    <meta name="twitter:description" content="製作 `.ics` 檔案以匯入通用日曆軟體！"> 
-    <meta property="og:description" content="製作 `.ics` 檔案以匯入通用日曆軟體！">
-    <meta property="og:site_name" content="NTUST Calednar Maker | 台科大日曆製作軟體"> 
-    <meta name="twitter:site" content="NTUST Calednar Maker | 台科大日曆製作軟體">
+    <meta property="og:image" content="/src/assets/ntust_so_hard.png" />
+    <meta name="theme-color" content="#d15dcb" />
+    <meta
+      name="twitter:description"
+      content="製作 `.ics` 檔案以匯入通用日曆軟體！"
+    />
+    <meta
+      property="og:description"
+      content="製作 `.ics` 檔案以匯入通用日曆軟體！"
+    />
+    <meta
+      property="og:site_name"
+      content="NTUST Calednar Maker | 台科大日曆製作軟體"
+    />
+    <meta
+      name="twitter:site"
+      content="NTUST Calednar Maker | 台科大日曆製作軟體"
+    />
     <meta content="https://ntust-calendar-maker.zudo.cc/" property="og:url" />
   </head>
   <!--

--- a/package.json
+++ b/package.json
@@ -5,7 +5,10 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "eslint . --ext .js,.vue",
+    "format": "prettier --write .",
+    "check": "npm run lint && npm run format"
   },
   "dependencies": {
     "@primevue/themes": "^4.2.4",
@@ -15,7 +18,12 @@
     "vue": "^3.2.45"
   },
   "devDependencies": {
+    "@eslint/js": "^9.22.0",
     "@vitejs/plugin-vue": "^4.0.0",
+    "eslint": "^9.22.0",
+    "eslint-plugin-vue": "^10.0.0",
+    "globals": "^16.0.0",
+    "prettier": "3.5.3",
     "vite": "^4.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,17 +1,16 @@
-lockfileVersion: '9.0'
+lockfileVersion: "9.0"
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
-
   .:
     dependencies:
-      '@primevue/themes':
+      "@primevue/themes":
         specifier: ^4.2.4
         version: 4.2.4
-      '@vuepic/vue-datepicker':
+      "@vuepic/vue-datepicker":
         specifier: ^8.1.1
         version: 8.1.1(vue@3.2.47)
       ics:
@@ -24,347 +23,1222 @@ importers:
         specifier: ^3.2.45
         version: 3.2.47
     devDependencies:
-      '@vitejs/plugin-vue':
+      "@eslint/js":
+        specifier: ^9.22.0
+        version: 9.22.0
+      "@vitejs/plugin-vue":
         specifier: ^4.0.0
         version: 4.0.0(vite@4.1.1)(vue@3.2.47)
+      eslint:
+        specifier: ^9.22.0
+        version: 9.22.0
+      eslint-plugin-vue:
+        specifier: ^10.0.0
+        version: 10.0.0(eslint@9.22.0)(vue-eslint-parser@10.1.1(eslint@9.22.0))
+      globals:
+        specifier: ^16.0.0
+        version: 16.0.0
+      prettier:
+        specifier: 3.5.3
+        version: 3.5.3
       vite:
         specifier: ^4.1.0
         version: 4.1.1
 
 packages:
+  "@babel/helper-string-parser@7.19.4":
+    resolution:
+      {
+        integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-string-parser@7.19.4':
-    resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
-    engines: {node: '>=6.9.0'}
+  "@babel/helper-validator-identifier@7.19.1":
+    resolution:
+      {
+        integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@babel/helper-validator-identifier@7.19.1':
-    resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.20.3':
-    resolution: {integrity: sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==}
-    engines: {node: '>=6.0.0'}
+  "@babel/parser@7.20.3":
+    resolution:
+      {
+        integrity: sha512-OP/s5a94frIPXwjzEcv5S/tpQfc6XhxYUnmWpgdqMWGgYCuErA3SzozaRAMQgSZWKeTJxht9aWAkUY+0UzvOFg==,
+      }
+    engines: { node: ">=6.0.0" }
     hasBin: true
 
-  '@babel/types@7.20.2':
-    resolution: {integrity: sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==}
-    engines: {node: '>=6.9.0'}
+  "@babel/types@7.20.2":
+    resolution:
+      {
+        integrity: sha512-FnnvsNWgZCr232sqtXggapvlkk/tuwR/qhGzcmxI0GXLCjmPYQPzio2FbdlWuY6y1sHFfQKk+rRbUZ9VStQMog==,
+      }
+    engines: { node: ">=6.9.0" }
 
-  '@esbuild/android-arm64@0.16.17':
-    resolution: {integrity: sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==}
-    engines: {node: '>=12'}
+  "@esbuild/android-arm64@0.16.17":
+    resolution:
+      {
+        integrity: sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.16.17':
-    resolution: {integrity: sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==}
-    engines: {node: '>=12'}
+  "@esbuild/android-arm@0.16.17":
+    resolution:
+      {
+        integrity: sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.16.17':
-    resolution: {integrity: sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==}
-    engines: {node: '>=12'}
+  "@esbuild/android-x64@0.16.17":
+    resolution:
+      {
+        integrity: sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.16.17':
-    resolution: {integrity: sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==}
-    engines: {node: '>=12'}
+  "@esbuild/darwin-arm64@0.16.17":
+    resolution:
+      {
+        integrity: sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.16.17':
-    resolution: {integrity: sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==}
-    engines: {node: '>=12'}
+  "@esbuild/darwin-x64@0.16.17":
+    resolution:
+      {
+        integrity: sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.16.17':
-    resolution: {integrity: sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==}
-    engines: {node: '>=12'}
+  "@esbuild/freebsd-arm64@0.16.17":
+    resolution:
+      {
+        integrity: sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.16.17':
-    resolution: {integrity: sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==}
-    engines: {node: '>=12'}
+  "@esbuild/freebsd-x64@0.16.17":
+    resolution:
+      {
+        integrity: sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.16.17':
-    resolution: {integrity: sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-arm64@0.16.17":
+    resolution:
+      {
+        integrity: sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.16.17':
-    resolution: {integrity: sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-arm@0.16.17":
+    resolution:
+      {
+        integrity: sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.16.17':
-    resolution: {integrity: sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-ia32@0.16.17":
+    resolution:
+      {
+        integrity: sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==,
+      }
+    engines: { node: ">=12" }
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.16.17':
-    resolution: {integrity: sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-loong64@0.16.17":
+    resolution:
+      {
+        integrity: sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==,
+      }
+    engines: { node: ">=12" }
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.16.17':
-    resolution: {integrity: sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-mips64el@0.16.17":
+    resolution:
+      {
+        integrity: sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==,
+      }
+    engines: { node: ">=12" }
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.16.17':
-    resolution: {integrity: sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-ppc64@0.16.17":
+    resolution:
+      {
+        integrity: sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==,
+      }
+    engines: { node: ">=12" }
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.16.17':
-    resolution: {integrity: sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-riscv64@0.16.17":
+    resolution:
+      {
+        integrity: sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==,
+      }
+    engines: { node: ">=12" }
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.16.17':
-    resolution: {integrity: sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-s390x@0.16.17":
+    resolution:
+      {
+        integrity: sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==,
+      }
+    engines: { node: ">=12" }
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.16.17':
-    resolution: {integrity: sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==}
-    engines: {node: '>=12'}
+  "@esbuild/linux-x64@0.16.17":
+    resolution:
+      {
+        integrity: sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-x64@0.16.17':
-    resolution: {integrity: sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==}
-    engines: {node: '>=12'}
+  "@esbuild/netbsd-x64@0.16.17":
+    resolution:
+      {
+        integrity: sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-x64@0.16.17':
-    resolution: {integrity: sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==}
-    engines: {node: '>=12'}
+  "@esbuild/openbsd-x64@0.16.17":
+    resolution:
+      {
+        integrity: sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/sunos-x64@0.16.17':
-    resolution: {integrity: sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==}
-    engines: {node: '>=12'}
+  "@esbuild/sunos-x64@0.16.17":
+    resolution:
+      {
+        integrity: sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.16.17':
-    resolution: {integrity: sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==}
-    engines: {node: '>=12'}
+  "@esbuild/win32-arm64@0.16.17":
+    resolution:
+      {
+        integrity: sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==,
+      }
+    engines: { node: ">=12" }
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.16.17':
-    resolution: {integrity: sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==}
-    engines: {node: '>=12'}
+  "@esbuild/win32-ia32@0.16.17":
+    resolution:
+      {
+        integrity: sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==,
+      }
+    engines: { node: ">=12" }
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.16.17':
-    resolution: {integrity: sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==}
-    engines: {node: '>=12'}
+  "@esbuild/win32-x64@0.16.17":
+    resolution:
+      {
+        integrity: sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==,
+      }
+    engines: { node: ">=12" }
     cpu: [x64]
     os: [win32]
 
-  '@primeuix/styled@0.3.2':
-    resolution: {integrity: sha512-ColZes0+/WKqH4ob2x8DyNYf1NENpe5ZguOvx5yCLxaP8EIMVhLjWLO/3umJiDnQU4XXMLkn2mMHHw+fhTX/mw==}
-    engines: {node: '>=12.11.0'}
+  "@eslint-community/eslint-utils@4.4.1":
+    resolution:
+      {
+        integrity: sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==,
+      }
+    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
-  '@primeuix/utils@0.3.2':
-    resolution: {integrity: sha512-B+nphqTQeq+i6JuICLdVWnDMjONome2sNz0xI65qIOyeB4EF12CoKRiCsxuZ5uKAkHi/0d1LqlQ9mIWRSdkavw==}
-    engines: {node: '>=12.11.0'}
+  "@eslint-community/regexpp@4.12.1":
+    resolution:
+      {
+        integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==,
+      }
+    engines: { node: ^12.0.0 || ^14.0.0 || >=16.0.0 }
 
-  '@primevue/core@4.2.4':
-    resolution: {integrity: sha512-QFvPcGSvyIhZPLdnjJnYrwbDtwbA1/FyGLI7VYDgYv4twsgtLw0kgKDyWB1uwM0xdJhv8CCmu7hfxcsPaLuIFg==}
-    engines: {node: '>=12.11.0'}
+  "@eslint/config-array@0.19.2":
+    resolution:
+      {
+        integrity: sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@eslint/config-helpers@0.1.0":
+    resolution:
+      {
+        integrity: sha512-kLrdPDJE1ckPo94kmPPf9Hfd0DU0Jw6oKYrhe+pwSC0iTUInmTa+w6fw8sGgcfkFJGNdWOUeOaDM4quW4a7OkA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@eslint/core@0.12.0":
+    resolution:
+      {
+        integrity: sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@eslint/eslintrc@3.3.0":
+    resolution:
+      {
+        integrity: sha512-yaVPAiNAalnCZedKLdR21GOGILMLKPyqSLWaAjQFvYA2i/ciDi8ArYVr69Anohb6cH2Ukhqti4aFnYyPm8wdwQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@eslint/js@9.22.0":
+    resolution:
+      {
+        integrity: sha512-vLFajx9o8d1/oL2ZkpMYbkLv8nDB6yaIwFNt7nI4+I80U/z03SxmfOMsLbvWr3p7C+Wnoh//aOu2pQW8cS0HCQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@eslint/object-schema@2.1.6":
+    resolution:
+      {
+        integrity: sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@eslint/plugin-kit@0.2.7":
+    resolution:
+      {
+        integrity: sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@humanfs/core@0.19.1":
+    resolution:
+      {
+        integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==,
+      }
+    engines: { node: ">=18.18.0" }
+
+  "@humanfs/node@0.16.6":
+    resolution:
+      {
+        integrity: sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==,
+      }
+    engines: { node: ">=18.18.0" }
+
+  "@humanwhocodes/module-importer@1.0.1":
+    resolution:
+      {
+        integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==,
+      }
+    engines: { node: ">=12.22" }
+
+  "@humanwhocodes/retry@0.3.1":
+    resolution:
+      {
+        integrity: sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==,
+      }
+    engines: { node: ">=18.18" }
+
+  "@humanwhocodes/retry@0.4.2":
+    resolution:
+      {
+        integrity: sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==,
+      }
+    engines: { node: ">=18.18" }
+
+  "@primeuix/styled@0.3.2":
+    resolution:
+      {
+        integrity: sha512-ColZes0+/WKqH4ob2x8DyNYf1NENpe5ZguOvx5yCLxaP8EIMVhLjWLO/3umJiDnQU4XXMLkn2mMHHw+fhTX/mw==,
+      }
+    engines: { node: ">=12.11.0" }
+
+  "@primeuix/utils@0.3.2":
+    resolution:
+      {
+        integrity: sha512-B+nphqTQeq+i6JuICLdVWnDMjONome2sNz0xI65qIOyeB4EF12CoKRiCsxuZ5uKAkHi/0d1LqlQ9mIWRSdkavw==,
+      }
+    engines: { node: ">=12.11.0" }
+
+  "@primevue/core@4.2.4":
+    resolution:
+      {
+        integrity: sha512-QFvPcGSvyIhZPLdnjJnYrwbDtwbA1/FyGLI7VYDgYv4twsgtLw0kgKDyWB1uwM0xdJhv8CCmu7hfxcsPaLuIFg==,
+      }
+    engines: { node: ">=12.11.0" }
     peerDependencies:
       vue: ^3.3.0
 
-  '@primevue/icons@4.2.4':
-    resolution: {integrity: sha512-vteUFM7qvWiDJWxhBbDRgc2VY6kQQyJ91yOukqfWHy4gAgfTz1jiUXMAzc7j269oh4CNFpTNhCe9riS7402HGg==}
-    engines: {node: '>=12.11.0'}
+  "@primevue/icons@4.2.4":
+    resolution:
+      {
+        integrity: sha512-vteUFM7qvWiDJWxhBbDRgc2VY6kQQyJ91yOukqfWHy4gAgfTz1jiUXMAzc7j269oh4CNFpTNhCe9riS7402HGg==,
+      }
+    engines: { node: ">=12.11.0" }
 
-  '@primevue/themes@4.2.4':
-    resolution: {integrity: sha512-nVM8/8qoV+lxSTK2k6Q19xyjrBlOjrgPzoA9OneKhlMYucBjWhSf3dBQaB9JgXRXAEwV5bzh4KPfcrMqn53QJA==}
-    engines: {node: '>=12.11.0'}
+  "@primevue/themes@4.2.4":
+    resolution:
+      {
+        integrity: sha512-nVM8/8qoV+lxSTK2k6Q19xyjrBlOjrgPzoA9OneKhlMYucBjWhSf3dBQaB9JgXRXAEwV5bzh4KPfcrMqn53QJA==,
+      }
+    engines: { node: ">=12.11.0" }
 
-  '@vitejs/plugin-vue@4.0.0':
-    resolution: {integrity: sha512-e0X4jErIxAB5oLtDqbHvHpJe/uWNkdpYV83AOG2xo2tEVSzCzewgJMtREZM30wXnM5ls90hxiOtAuVU6H5JgbA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
+  "@types/estree@1.0.6":
+    resolution:
+      {
+        integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==,
+      }
+
+  "@types/json-schema@7.0.15":
+    resolution:
+      {
+        integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==,
+      }
+
+  "@vitejs/plugin-vue@4.0.0":
+    resolution:
+      {
+        integrity: sha512-e0X4jErIxAB5oLtDqbHvHpJe/uWNkdpYV83AOG2xo2tEVSzCzewgJMtREZM30wXnM5ls90hxiOtAuVU6H5JgbA==,
+      }
+    engines: { node: ^14.18.0 || >=16.0.0 }
     peerDependencies:
       vite: ^4.0.0
       vue: ^3.2.25
 
-  '@vue/compiler-core@3.2.47':
-    resolution: {integrity: sha512-p4D7FDnQb7+YJmO2iPEv0SQNeNzcbHdGByJDsT4lynf63AFkOTFN07HsiRSvjGo0QrxR/o3d0hUyNCUnBU2Tig==}
+  "@vue/compiler-core@3.2.47":
+    resolution:
+      {
+        integrity: sha512-p4D7FDnQb7+YJmO2iPEv0SQNeNzcbHdGByJDsT4lynf63AFkOTFN07HsiRSvjGo0QrxR/o3d0hUyNCUnBU2Tig==,
+      }
 
-  '@vue/compiler-dom@3.2.47':
-    resolution: {integrity: sha512-dBBnEHEPoftUiS03a4ggEig74J2YBZ2UIeyfpcRM2tavgMWo4bsEfgCGsu+uJIL/vax9S+JztH8NmQerUo7shQ==}
+  "@vue/compiler-dom@3.2.47":
+    resolution:
+      {
+        integrity: sha512-dBBnEHEPoftUiS03a4ggEig74J2YBZ2UIeyfpcRM2tavgMWo4bsEfgCGsu+uJIL/vax9S+JztH8NmQerUo7shQ==,
+      }
 
-  '@vue/compiler-sfc@3.2.47':
-    resolution: {integrity: sha512-rog05W+2IFfxjMcFw10tM9+f7i/+FFpZJJ5XHX72NP9eC2uRD+42M3pYcQqDXVYoj74kHMSEdQ/WmCjt8JFksQ==}
+  "@vue/compiler-sfc@3.2.47":
+    resolution:
+      {
+        integrity: sha512-rog05W+2IFfxjMcFw10tM9+f7i/+FFpZJJ5XHX72NP9eC2uRD+42M3pYcQqDXVYoj74kHMSEdQ/WmCjt8JFksQ==,
+      }
 
-  '@vue/compiler-ssr@3.2.47':
-    resolution: {integrity: sha512-wVXC+gszhulcMD8wpxMsqSOpvDZ6xKXSVWkf50Guf/S+28hTAXPDYRTbLQ3EDkOP5Xz/+SY37YiwDquKbJOgZw==}
+  "@vue/compiler-ssr@3.2.47":
+    resolution:
+      {
+        integrity: sha512-wVXC+gszhulcMD8wpxMsqSOpvDZ6xKXSVWkf50Guf/S+28hTAXPDYRTbLQ3EDkOP5Xz/+SY37YiwDquKbJOgZw==,
+      }
 
-  '@vue/reactivity-transform@3.2.47':
-    resolution: {integrity: sha512-m8lGXw8rdnPVVIdIFhf0LeQ/ixyHkH5plYuS83yop5n7ggVJU+z5v0zecwEnX7fa7HNLBhh2qngJJkxpwEEmYA==}
+  "@vue/reactivity-transform@3.2.47":
+    resolution:
+      {
+        integrity: sha512-m8lGXw8rdnPVVIdIFhf0LeQ/ixyHkH5plYuS83yop5n7ggVJU+z5v0zecwEnX7fa7HNLBhh2qngJJkxpwEEmYA==,
+      }
 
-  '@vue/reactivity@3.2.47':
-    resolution: {integrity: sha512-7khqQ/75oyyg+N/e+iwV6lpy1f5wq759NdlS1fpAhFXa8VeAIKGgk2E/C4VF59lx5b+Ezs5fpp/5WsRYXQiKxQ==}
+  "@vue/reactivity@3.2.47":
+    resolution:
+      {
+        integrity: sha512-7khqQ/75oyyg+N/e+iwV6lpy1f5wq759NdlS1fpAhFXa8VeAIKGgk2E/C4VF59lx5b+Ezs5fpp/5WsRYXQiKxQ==,
+      }
 
-  '@vue/runtime-core@3.2.47':
-    resolution: {integrity: sha512-RZxbLQIRB/K0ev0K9FXhNbBzT32H9iRtYbaXb0ZIz2usLms/D55dJR2t6cIEUn6vyhS3ALNvNthI+Q95C+NOpA==}
+  "@vue/runtime-core@3.2.47":
+    resolution:
+      {
+        integrity: sha512-RZxbLQIRB/K0ev0K9FXhNbBzT32H9iRtYbaXb0ZIz2usLms/D55dJR2t6cIEUn6vyhS3ALNvNthI+Q95C+NOpA==,
+      }
 
-  '@vue/runtime-dom@3.2.47':
-    resolution: {integrity: sha512-ArXrFTjS6TsDei4qwNvgrdmHtD930KgSKGhS5M+j8QxXrDJYLqYw4RRcDy1bz1m1wMmb6j+zGLifdVHtkXA7gA==}
+  "@vue/runtime-dom@3.2.47":
+    resolution:
+      {
+        integrity: sha512-ArXrFTjS6TsDei4qwNvgrdmHtD930KgSKGhS5M+j8QxXrDJYLqYw4RRcDy1bz1m1wMmb6j+zGLifdVHtkXA7gA==,
+      }
 
-  '@vue/server-renderer@3.2.47':
-    resolution: {integrity: sha512-dN9gc1i8EvmP9RCzvneONXsKfBRgqFeFZLurmHOveL7oH6HiFXJw5OGu294n1nHc/HMgTy6LulU/tv5/A7f/LA==}
+  "@vue/server-renderer@3.2.47":
+    resolution:
+      {
+        integrity: sha512-dN9gc1i8EvmP9RCzvneONXsKfBRgqFeFZLurmHOveL7oH6HiFXJw5OGu294n1nHc/HMgTy6LulU/tv5/A7f/LA==,
+      }
     peerDependencies:
       vue: 3.2.47
 
-  '@vue/shared@3.2.47':
-    resolution: {integrity: sha512-BHGyyGN3Q97EZx0taMQ+OLNuZcW3d37ZEVmEAyeoA9ERdGvm9Irc/0Fua8SNyOtV1w6BS4q25wbMzJujO9HIfQ==}
+  "@vue/shared@3.2.47":
+    resolution:
+      {
+        integrity: sha512-BHGyyGN3Q97EZx0taMQ+OLNuZcW3d37ZEVmEAyeoA9ERdGvm9Irc/0Fua8SNyOtV1w6BS4q25wbMzJujO9HIfQ==,
+      }
 
-  '@vuepic/vue-datepicker@8.1.1':
-    resolution: {integrity: sha512-/t9+dROb/hYN/DInff8ctIiVm5tVyuJdiWA+nWcjHOLjUhvAQ9vyJwhxAkoWX5o0EB5x5XeCME2cajfTPz86RA==}
-    engines: {node: '>=18.12.0'}
+  "@vuepic/vue-datepicker@8.1.1":
+    resolution:
+      {
+        integrity: sha512-/t9+dROb/hYN/DInff8ctIiVm5tVyuJdiWA+nWcjHOLjUhvAQ9vyJwhxAkoWX5o0EB5x5XeCME2cajfTPz86RA==,
+      }
+    engines: { node: ">=18.12.0" }
     peerDependencies:
-      vue: '>=3.2.0'
+      vue: ">=3.2.0"
 
-  csstype@2.6.21:
-    resolution: {integrity: sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==}
+  acorn-jsx@5.3.2:
+    resolution:
+      {
+        integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==,
+      }
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  date-fns@3.3.1:
-    resolution: {integrity: sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==}
-
-  esbuild@0.16.17:
-    resolution: {integrity: sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==}
-    engines: {node: '>=12'}
+  acorn@8.14.1:
+    resolution:
+      {
+        integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==,
+      }
+    engines: { node: ">=0.4.0" }
     hasBin: true
 
+  ajv@6.12.6:
+    resolution:
+      {
+        integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==,
+      }
+
+  ansi-styles@4.3.0:
+    resolution:
+      {
+        integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
+      }
+    engines: { node: ">=8" }
+
+  argparse@2.0.1:
+    resolution:
+      {
+        integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
+      }
+
+  balanced-match@1.0.2:
+    resolution:
+      {
+        integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==,
+      }
+
+  boolbase@1.0.0:
+    resolution:
+      {
+        integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==,
+      }
+
+  brace-expansion@1.1.11:
+    resolution:
+      {
+        integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==,
+      }
+
+  callsites@3.1.0:
+    resolution:
+      {
+        integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==,
+      }
+    engines: { node: ">=6" }
+
+  chalk@4.1.2:
+    resolution:
+      {
+        integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==,
+      }
+    engines: { node: ">=10" }
+
+  color-convert@2.0.1:
+    resolution:
+      {
+        integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
+      }
+    engines: { node: ">=7.0.0" }
+
+  color-name@1.1.4:
+    resolution:
+      {
+        integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
+      }
+
+  concat-map@0.0.1:
+    resolution:
+      {
+        integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==,
+      }
+
+  cross-spawn@7.0.6:
+    resolution:
+      {
+        integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==,
+      }
+    engines: { node: ">= 8" }
+
+  cssesc@3.0.0:
+    resolution:
+      {
+        integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==,
+      }
+    engines: { node: ">=4" }
+    hasBin: true
+
+  csstype@2.6.21:
+    resolution:
+      {
+        integrity: sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==,
+      }
+
+  date-fns@3.3.1:
+    resolution:
+      {
+        integrity: sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==,
+      }
+
+  debug@4.4.0:
+    resolution:
+      {
+        integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==,
+      }
+    engines: { node: ">=6.0" }
+    peerDependencies:
+      supports-color: "*"
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-is@0.1.4:
+    resolution:
+      {
+        integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==,
+      }
+
+  esbuild@0.16.17:
+    resolution:
+      {
+        integrity: sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==,
+      }
+    engines: { node: ">=12" }
+    hasBin: true
+
+  escape-string-regexp@4.0.0:
+    resolution:
+      {
+        integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==,
+      }
+    engines: { node: ">=10" }
+
+  eslint-plugin-vue@10.0.0:
+    resolution:
+      {
+        integrity: sha512-XKckedtajqwmaX6u1VnECmZ6xJt+YvlmMzBPZd+/sI3ub2lpYZyFnsyWo7c3nMOQKJQudeyk1lw/JxdgeKT64w==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      vue-eslint-parser: ^10.0.0
+
+  eslint-scope@8.3.0:
+    resolution:
+      {
+        integrity: sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  eslint-visitor-keys@3.4.3:
+    resolution:
+      {
+        integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==,
+      }
+    engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
+
+  eslint-visitor-keys@4.2.0:
+    resolution:
+      {
+        integrity: sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  eslint@9.22.0:
+    resolution:
+      {
+        integrity: sha512-9V/QURhsRN40xuHXWjV64yvrzMjcz7ZyNoF2jJFmy9j/SLk0u1OLSZgXi28MrXjymnjEGSR80WCdab3RGMDveQ==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    hasBin: true
+    peerDependencies:
+      jiti: "*"
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@10.3.0:
+    resolution:
+      {
+        integrity: sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  esquery@1.6.0:
+    resolution:
+      {
+        integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==,
+      }
+    engines: { node: ">=0.10" }
+
+  esrecurse@4.3.0:
+    resolution:
+      {
+        integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==,
+      }
+    engines: { node: ">=4.0" }
+
+  estraverse@5.3.0:
+    resolution:
+      {
+        integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==,
+      }
+    engines: { node: ">=4.0" }
+
   estree-walker@2.0.2:
-    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+    resolution:
+      {
+        integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==,
+      }
+
+  esutils@2.0.3:
+    resolution:
+      {
+        integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==,
+      }
+    engines: { node: ">=0.10.0" }
+
+  fast-deep-equal@3.1.3:
+    resolution:
+      {
+        integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
+      }
+
+  fast-json-stable-stringify@2.1.0:
+    resolution:
+      {
+        integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==,
+      }
+
+  fast-levenshtein@2.0.6:
+    resolution:
+      {
+        integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
+      }
+
+  file-entry-cache@8.0.0:
+    resolution:
+      {
+        integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==,
+      }
+    engines: { node: ">=16.0.0" }
+
+  find-up@5.0.0:
+    resolution:
+      {
+        integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==,
+      }
+    engines: { node: ">=10" }
+
+  flat-cache@4.0.1:
+    resolution:
+      {
+        integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==,
+      }
+    engines: { node: ">=16" }
+
+  flatted@3.3.3:
+    resolution:
+      {
+        integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==,
+      }
 
   fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    resolution:
+      {
+        integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
     os: [darwin]
 
   function-bind@1.1.1:
-    resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
+    resolution:
+      {
+        integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==,
+      }
+
+  glob-parent@6.0.2:
+    resolution:
+      {
+        integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==,
+      }
+    engines: { node: ">=10.13.0" }
+
+  globals@14.0.0:
+    resolution:
+      {
+        integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==,
+      }
+    engines: { node: ">=18" }
+
+  globals@16.0.0:
+    resolution:
+      {
+        integrity: sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A==,
+      }
+    engines: { node: ">=18" }
+
+  has-flag@4.0.0:
+    resolution:
+      {
+        integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
+      }
+    engines: { node: ">=8" }
 
   has@1.0.3:
-    resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
-    engines: {node: '>= 0.4.0'}
+    resolution:
+      {
+        integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==,
+      }
+    engines: { node: ">= 0.4.0" }
 
   ics@3.7.2:
-    resolution: {integrity: sha512-UC5bBJYKyzkYZv4/AoIV9dsZw+rwFkUOtHHhnxmb0HTUEpfDmfl5sB9DlePKrTxx6SGMXiIQbiElf66viSTB0A==}
+    resolution:
+      {
+        integrity: sha512-UC5bBJYKyzkYZv4/AoIV9dsZw+rwFkUOtHHhnxmb0HTUEpfDmfl5sB9DlePKrTxx6SGMXiIQbiElf66viSTB0A==,
+      }
+
+  ignore@5.3.2:
+    resolution:
+      {
+        integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==,
+      }
+    engines: { node: ">= 4" }
+
+  import-fresh@3.3.1:
+    resolution:
+      {
+        integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==,
+      }
+    engines: { node: ">=6" }
+
+  imurmurhash@0.1.4:
+    resolution:
+      {
+        integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==,
+      }
+    engines: { node: ">=0.8.19" }
 
   is-core-module@2.11.0:
-    resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
+    resolution:
+      {
+        integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==,
+      }
 
-  magic-string@0.25.9:
-    resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
+  is-extglob@2.1.1:
+    resolution:
+      {
+        integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==,
+      }
+    engines: { node: ">=0.10.0" }
 
-  nanoid@3.3.4:
-    resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+  is-glob@4.0.3:
+    resolution:
+      {
+        integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==,
+      }
+    engines: { node: ">=0.10.0" }
+
+  isexe@2.0.0:
+    resolution:
+      {
+        integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==,
+      }
+
+  js-yaml@4.1.0:
+    resolution:
+      {
+        integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==,
+      }
     hasBin: true
 
+  json-buffer@3.0.1:
+    resolution:
+      {
+        integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==,
+      }
+
+  json-schema-traverse@0.4.1:
+    resolution:
+      {
+        integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==,
+      }
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution:
+      {
+        integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==,
+      }
+
+  keyv@4.5.4:
+    resolution:
+      {
+        integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==,
+      }
+
+  levn@0.4.1:
+    resolution:
+      {
+        integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==,
+      }
+    engines: { node: ">= 0.8.0" }
+
+  locate-path@6.0.0:
+    resolution:
+      {
+        integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==,
+      }
+    engines: { node: ">=10" }
+
+  lodash.merge@4.6.2:
+    resolution:
+      {
+        integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==,
+      }
+
+  lodash@4.17.21:
+    resolution:
+      {
+        integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==,
+      }
+
+  magic-string@0.25.9:
+    resolution:
+      {
+        integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==,
+      }
+
+  minimatch@3.1.2:
+    resolution:
+      {
+        integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==,
+      }
+
+  ms@2.1.3:
+    resolution:
+      {
+        integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
+      }
+
+  nanoid@3.3.4:
+    resolution:
+      {
+        integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==,
+      }
+    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
+    hasBin: true
+
+  natural-compare@1.4.0:
+    resolution:
+      {
+        integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==,
+      }
+
+  nth-check@2.1.1:
+    resolution:
+      {
+        integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==,
+      }
+
+  optionator@0.9.4:
+    resolution:
+      {
+        integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==,
+      }
+    engines: { node: ">= 0.8.0" }
+
+  p-limit@3.1.0:
+    resolution:
+      {
+        integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==,
+      }
+    engines: { node: ">=10" }
+
+  p-locate@5.0.0:
+    resolution:
+      {
+        integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==,
+      }
+    engines: { node: ">=10" }
+
+  parent-module@1.0.1:
+    resolution:
+      {
+        integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==,
+      }
+    engines: { node: ">=6" }
+
+  path-exists@4.0.0:
+    resolution:
+      {
+        integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==,
+      }
+    engines: { node: ">=8" }
+
+  path-key@3.1.1:
+    resolution:
+      {
+        integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==,
+      }
+    engines: { node: ">=8" }
+
   path-parse@1.0.7:
-    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+    resolution:
+      {
+        integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==,
+      }
 
   picocolors@1.0.0:
-    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+    resolution:
+      {
+        integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==,
+      }
+
+  postcss-selector-parser@6.1.2:
+    resolution:
+      {
+        integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==,
+      }
+    engines: { node: ">=4" }
 
   postcss@8.4.18:
-    resolution: {integrity: sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==}
-    engines: {node: ^10 || ^12 || >=14}
+    resolution:
+      {
+        integrity: sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==,
+      }
+    engines: { node: ^10 || ^12 || >=14 }
 
   postcss@8.4.21:
-    resolution: {integrity: sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==}
-    engines: {node: ^10 || ^12 || >=14}
+    resolution:
+      {
+        integrity: sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==,
+      }
+    engines: { node: ^10 || ^12 || >=14 }
+
+  prelude-ls@1.2.1:
+    resolution:
+      {
+        integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==,
+      }
+    engines: { node: ">= 0.8.0" }
+
+  prettier@3.5.3:
+    resolution:
+      {
+        integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==,
+      }
+    engines: { node: ">=14" }
+    hasBin: true
 
   primevue@4.2.4:
-    resolution: {integrity: sha512-aMQymoO489isReSF/bScypswOnLBU29qkeTulGj3Wntb9plvzTIWjA4+iyDOsyxGmV5GVIvD+DuTw5FNCDWgSw==}
-    engines: {node: '>=12.11.0'}
+    resolution:
+      {
+        integrity: sha512-aMQymoO489isReSF/bScypswOnLBU29qkeTulGj3Wntb9plvzTIWjA4+iyDOsyxGmV5GVIvD+DuTw5FNCDWgSw==,
+      }
+    engines: { node: ">=12.11.0" }
 
   property-expr@2.0.6:
-    resolution: {integrity: sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==}
+    resolution:
+      {
+        integrity: sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==,
+      }
+
+  punycode@2.3.1:
+    resolution:
+      {
+        integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==,
+      }
+    engines: { node: ">=6" }
+
+  resolve-from@4.0.0:
+    resolution:
+      {
+        integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==,
+      }
+    engines: { node: ">=4" }
 
   resolve@1.22.1:
-    resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
+    resolution:
+      {
+        integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==,
+      }
     hasBin: true
 
   rollup@3.14.0:
-    resolution: {integrity: sha512-o23sdgCLcLSe3zIplT9nQ1+r97okuaiR+vmAPZPTDYB7/f3tgWIYNyiQveMsZwshBT0is4eGax/HH83Q7CG+/Q==}
-    engines: {node: '>=14.18.0', npm: '>=8.0.0'}
+    resolution:
+      {
+        integrity: sha512-o23sdgCLcLSe3zIplT9nQ1+r97okuaiR+vmAPZPTDYB7/f3tgWIYNyiQveMsZwshBT0is4eGax/HH83Q7CG+/Q==,
+      }
+    engines: { node: ">=14.18.0", npm: ">=8.0.0" }
     hasBin: true
 
   runes2@1.1.4:
-    resolution: {integrity: sha512-LNPnEDPOOU4ehF71m5JoQyzT2yxwD6ZreFJ7MxZUAoMKNMY1XrAo60H1CUoX5ncSm0rIuKlqn9JZNRrRkNou2g==}
+    resolution:
+      {
+        integrity: sha512-LNPnEDPOOU4ehF71m5JoQyzT2yxwD6ZreFJ7MxZUAoMKNMY1XrAo60H1CUoX5ncSm0rIuKlqn9JZNRrRkNou2g==,
+      }
+
+  semver@7.7.1:
+    resolution:
+      {
+        integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==,
+      }
+    engines: { node: ">=10" }
+    hasBin: true
+
+  shebang-command@2.0.0:
+    resolution:
+      {
+        integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==,
+      }
+    engines: { node: ">=8" }
+
+  shebang-regex@3.0.0:
+    resolution:
+      {
+        integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
+      }
+    engines: { node: ">=8" }
 
   source-map-js@1.0.2:
-    resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==,
+      }
+    engines: { node: ">=0.10.0" }
 
   source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
-    engines: {node: '>=0.10.0'}
+    resolution:
+      {
+        integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==,
+      }
+    engines: { node: ">=0.10.0" }
 
   sourcemap-codec@1.4.8:
-    resolution: {integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==}
+    resolution:
+      {
+        integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==,
+      }
     deprecated: Please use @jridgewell/sourcemap-codec instead
 
+  strip-json-comments@3.1.1:
+    resolution:
+      {
+        integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==,
+      }
+    engines: { node: ">=8" }
+
+  supports-color@7.2.0:
+    resolution:
+      {
+        integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
+      }
+    engines: { node: ">=8" }
+
   supports-preserve-symlinks-flag@1.0.0:
-    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
-    engines: {node: '>= 0.4'}
+    resolution:
+      {
+        integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==,
+      }
+    engines: { node: ">= 0.4" }
 
   tiny-case@1.0.3:
-    resolution: {integrity: sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==}
+    resolution:
+      {
+        integrity: sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==,
+      }
 
   to-fast-properties@2.0.0:
-    resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
-    engines: {node: '>=4'}
+    resolution:
+      {
+        integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==,
+      }
+    engines: { node: ">=4" }
 
   toposort@2.0.2:
-    resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
+    resolution:
+      {
+        integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==,
+      }
+
+  type-check@0.4.0:
+    resolution:
+      {
+        integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==,
+      }
+    engines: { node: ">= 0.8.0" }
 
   type-fest@2.19.0:
-    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
-    engines: {node: '>=12.20'}
+    resolution:
+      {
+        integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==,
+      }
+    engines: { node: ">=12.20" }
+
+  uri-js@4.4.1:
+    resolution:
+      {
+        integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
+      }
+
+  util-deprecate@1.0.2:
+    resolution:
+      {
+        integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
+      }
 
   vite@4.1.1:
-    resolution: {integrity: sha512-LM9WWea8vsxhr782r9ntg+bhSFS06FJgCvvB0+8hf8UWtvaiDagKYWXndjfX6kGl74keHJUcpzrQliDXZlF5yg==}
-    engines: {node: ^14.18.0 || >=16.0.0}
+    resolution:
+      {
+        integrity: sha512-LM9WWea8vsxhr782r9ntg+bhSFS06FJgCvvB0+8hf8UWtvaiDagKYWXndjfX6kGl74keHJUcpzrQliDXZlF5yg==,
+      }
+    engines: { node: ^14.18.0 || >=16.0.0 }
     hasBin: true
     peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
+      "@types/node": ">= 14"
+      less: "*"
+      sass: "*"
+      stylus: "*"
+      sugarss: "*"
       terser: ^5.4.0
     peerDependenciesMeta:
-      '@types/node':
+      "@types/node":
         optional: true
       less:
         optional: true
@@ -377,223 +1251,496 @@ packages:
       terser:
         optional: true
 
+  vue-eslint-parser@10.1.1:
+    resolution:
+      {
+        integrity: sha512-bh2Z/Au5slro9QJ3neFYLanZtb1jH+W2bKqGHXAoYD4vZgNG3KeotL7JpPv5xzY4UXUXJl7TrIsnzECH63kd3Q==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+
   vue@3.2.47:
-    resolution: {integrity: sha512-60188y/9Dc9WVrAZeUVSDxRQOZ+z+y5nO2ts9jWXSTkMvayiWxCWOWtBQoYjLeccfXkiiPZWAHcV+WTPhkqJHQ==}
+    resolution:
+      {
+        integrity: sha512-60188y/9Dc9WVrAZeUVSDxRQOZ+z+y5nO2ts9jWXSTkMvayiWxCWOWtBQoYjLeccfXkiiPZWAHcV+WTPhkqJHQ==,
+      }
+
+  which@2.0.2:
+    resolution:
+      {
+        integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
+      }
+    engines: { node: ">= 8" }
+    hasBin: true
+
+  word-wrap@1.2.5:
+    resolution:
+      {
+        integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==,
+      }
+    engines: { node: ">=0.10.0" }
+
+  xml-name-validator@4.0.0:
+    resolution:
+      {
+        integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==,
+      }
+    engines: { node: ">=12" }
+
+  yocto-queue@0.1.0:
+    resolution:
+      {
+        integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==,
+      }
+    engines: { node: ">=10" }
 
   yup@1.3.3:
-    resolution: {integrity: sha512-v8QwZSsHH2K3/G9WSkp6mZKO+hugKT1EmnMqLNUcfu51HU9MDyhlETT/JgtzprnrnQHPWsjc6MUDMBp/l9fNnw==}
+    resolution:
+      {
+        integrity: sha512-v8QwZSsHH2K3/G9WSkp6mZKO+hugKT1EmnMqLNUcfu51HU9MDyhlETT/JgtzprnrnQHPWsjc6MUDMBp/l9fNnw==,
+      }
 
 snapshots:
+  "@babel/helper-string-parser@7.19.4": {}
 
-  '@babel/helper-string-parser@7.19.4': {}
+  "@babel/helper-validator-identifier@7.19.1": {}
 
-  '@babel/helper-validator-identifier@7.19.1': {}
-
-  '@babel/parser@7.20.3':
+  "@babel/parser@7.20.3":
     dependencies:
-      '@babel/types': 7.20.2
+      "@babel/types": 7.20.2
 
-  '@babel/types@7.20.2':
+  "@babel/types@7.20.2":
     dependencies:
-      '@babel/helper-string-parser': 7.19.4
-      '@babel/helper-validator-identifier': 7.19.1
+      "@babel/helper-string-parser": 7.19.4
+      "@babel/helper-validator-identifier": 7.19.1
       to-fast-properties: 2.0.0
 
-  '@esbuild/android-arm64@0.16.17':
+  "@esbuild/android-arm64@0.16.17":
     optional: true
 
-  '@esbuild/android-arm@0.16.17':
+  "@esbuild/android-arm@0.16.17":
     optional: true
 
-  '@esbuild/android-x64@0.16.17':
+  "@esbuild/android-x64@0.16.17":
     optional: true
 
-  '@esbuild/darwin-arm64@0.16.17':
+  "@esbuild/darwin-arm64@0.16.17":
     optional: true
 
-  '@esbuild/darwin-x64@0.16.17':
+  "@esbuild/darwin-x64@0.16.17":
     optional: true
 
-  '@esbuild/freebsd-arm64@0.16.17':
+  "@esbuild/freebsd-arm64@0.16.17":
     optional: true
 
-  '@esbuild/freebsd-x64@0.16.17':
+  "@esbuild/freebsd-x64@0.16.17":
     optional: true
 
-  '@esbuild/linux-arm64@0.16.17':
+  "@esbuild/linux-arm64@0.16.17":
     optional: true
 
-  '@esbuild/linux-arm@0.16.17':
+  "@esbuild/linux-arm@0.16.17":
     optional: true
 
-  '@esbuild/linux-ia32@0.16.17':
+  "@esbuild/linux-ia32@0.16.17":
     optional: true
 
-  '@esbuild/linux-loong64@0.16.17':
+  "@esbuild/linux-loong64@0.16.17":
     optional: true
 
-  '@esbuild/linux-mips64el@0.16.17':
+  "@esbuild/linux-mips64el@0.16.17":
     optional: true
 
-  '@esbuild/linux-ppc64@0.16.17':
+  "@esbuild/linux-ppc64@0.16.17":
     optional: true
 
-  '@esbuild/linux-riscv64@0.16.17':
+  "@esbuild/linux-riscv64@0.16.17":
     optional: true
 
-  '@esbuild/linux-s390x@0.16.17':
+  "@esbuild/linux-s390x@0.16.17":
     optional: true
 
-  '@esbuild/linux-x64@0.16.17':
+  "@esbuild/linux-x64@0.16.17":
     optional: true
 
-  '@esbuild/netbsd-x64@0.16.17':
+  "@esbuild/netbsd-x64@0.16.17":
     optional: true
 
-  '@esbuild/openbsd-x64@0.16.17':
+  "@esbuild/openbsd-x64@0.16.17":
     optional: true
 
-  '@esbuild/sunos-x64@0.16.17':
+  "@esbuild/sunos-x64@0.16.17":
     optional: true
 
-  '@esbuild/win32-arm64@0.16.17':
+  "@esbuild/win32-arm64@0.16.17":
     optional: true
 
-  '@esbuild/win32-ia32@0.16.17':
+  "@esbuild/win32-ia32@0.16.17":
     optional: true
 
-  '@esbuild/win32-x64@0.16.17':
+  "@esbuild/win32-x64@0.16.17":
     optional: true
 
-  '@primeuix/styled@0.3.2':
+  "@eslint-community/eslint-utils@4.4.1(eslint@9.22.0)":
     dependencies:
-      '@primeuix/utils': 0.3.2
+      eslint: 9.22.0
+      eslint-visitor-keys: 3.4.3
 
-  '@primeuix/utils@0.3.2': {}
+  "@eslint-community/regexpp@4.12.1": {}
 
-  '@primevue/core@4.2.4(vue@3.2.47)':
+  "@eslint/config-array@0.19.2":
     dependencies:
-      '@primeuix/styled': 0.3.2
-      '@primeuix/utils': 0.3.2
+      "@eslint/object-schema": 2.1.6
+      debug: 4.4.0
+      minimatch: 3.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  "@eslint/config-helpers@0.1.0": {}
+
+  "@eslint/core@0.12.0":
+    dependencies:
+      "@types/json-schema": 7.0.15
+
+  "@eslint/eslintrc@3.3.0":
+    dependencies:
+      ajv: 6.12.6
+      debug: 4.4.0
+      espree: 10.3.0
+      globals: 14.0.0
+      ignore: 5.3.2
+      import-fresh: 3.3.1
+      js-yaml: 4.1.0
+      minimatch: 3.1.2
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  "@eslint/js@9.22.0": {}
+
+  "@eslint/object-schema@2.1.6": {}
+
+  "@eslint/plugin-kit@0.2.7":
+    dependencies:
+      "@eslint/core": 0.12.0
+      levn: 0.4.1
+
+  "@humanfs/core@0.19.1": {}
+
+  "@humanfs/node@0.16.6":
+    dependencies:
+      "@humanfs/core": 0.19.1
+      "@humanwhocodes/retry": 0.3.1
+
+  "@humanwhocodes/module-importer@1.0.1": {}
+
+  "@humanwhocodes/retry@0.3.1": {}
+
+  "@humanwhocodes/retry@0.4.2": {}
+
+  "@primeuix/styled@0.3.2":
+    dependencies:
+      "@primeuix/utils": 0.3.2
+
+  "@primeuix/utils@0.3.2": {}
+
+  "@primevue/core@4.2.4(vue@3.2.47)":
+    dependencies:
+      "@primeuix/styled": 0.3.2
+      "@primeuix/utils": 0.3.2
       vue: 3.2.47
 
-  '@primevue/icons@4.2.4(vue@3.2.47)':
+  "@primevue/icons@4.2.4(vue@3.2.47)":
     dependencies:
-      '@primeuix/utils': 0.3.2
-      '@primevue/core': 4.2.4(vue@3.2.47)
+      "@primeuix/utils": 0.3.2
+      "@primevue/core": 4.2.4(vue@3.2.47)
     transitivePeerDependencies:
       - vue
 
-  '@primevue/themes@4.2.4':
+  "@primevue/themes@4.2.4":
     dependencies:
-      '@primeuix/styled': 0.3.2
+      "@primeuix/styled": 0.3.2
 
-  '@vitejs/plugin-vue@4.0.0(vite@4.1.1)(vue@3.2.47)':
+  "@types/estree@1.0.6": {}
+
+  "@types/json-schema@7.0.15": {}
+
+  "@vitejs/plugin-vue@4.0.0(vite@4.1.1)(vue@3.2.47)":
     dependencies:
       vite: 4.1.1
       vue: 3.2.47
 
-  '@vue/compiler-core@3.2.47':
+  "@vue/compiler-core@3.2.47":
     dependencies:
-      '@babel/parser': 7.20.3
-      '@vue/shared': 3.2.47
+      "@babel/parser": 7.20.3
+      "@vue/shared": 3.2.47
       estree-walker: 2.0.2
       source-map: 0.6.1
 
-  '@vue/compiler-dom@3.2.47':
+  "@vue/compiler-dom@3.2.47":
     dependencies:
-      '@vue/compiler-core': 3.2.47
-      '@vue/shared': 3.2.47
+      "@vue/compiler-core": 3.2.47
+      "@vue/shared": 3.2.47
 
-  '@vue/compiler-sfc@3.2.47':
+  "@vue/compiler-sfc@3.2.47":
     dependencies:
-      '@babel/parser': 7.20.3
-      '@vue/compiler-core': 3.2.47
-      '@vue/compiler-dom': 3.2.47
-      '@vue/compiler-ssr': 3.2.47
-      '@vue/reactivity-transform': 3.2.47
-      '@vue/shared': 3.2.47
+      "@babel/parser": 7.20.3
+      "@vue/compiler-core": 3.2.47
+      "@vue/compiler-dom": 3.2.47
+      "@vue/compiler-ssr": 3.2.47
+      "@vue/reactivity-transform": 3.2.47
+      "@vue/shared": 3.2.47
       estree-walker: 2.0.2
       magic-string: 0.25.9
       postcss: 8.4.18
       source-map: 0.6.1
 
-  '@vue/compiler-ssr@3.2.47':
+  "@vue/compiler-ssr@3.2.47":
     dependencies:
-      '@vue/compiler-dom': 3.2.47
-      '@vue/shared': 3.2.47
+      "@vue/compiler-dom": 3.2.47
+      "@vue/shared": 3.2.47
 
-  '@vue/reactivity-transform@3.2.47':
+  "@vue/reactivity-transform@3.2.47":
     dependencies:
-      '@babel/parser': 7.20.3
-      '@vue/compiler-core': 3.2.47
-      '@vue/shared': 3.2.47
+      "@babel/parser": 7.20.3
+      "@vue/compiler-core": 3.2.47
+      "@vue/shared": 3.2.47
       estree-walker: 2.0.2
       magic-string: 0.25.9
 
-  '@vue/reactivity@3.2.47':
+  "@vue/reactivity@3.2.47":
     dependencies:
-      '@vue/shared': 3.2.47
+      "@vue/shared": 3.2.47
 
-  '@vue/runtime-core@3.2.47':
+  "@vue/runtime-core@3.2.47":
     dependencies:
-      '@vue/reactivity': 3.2.47
-      '@vue/shared': 3.2.47
+      "@vue/reactivity": 3.2.47
+      "@vue/shared": 3.2.47
 
-  '@vue/runtime-dom@3.2.47':
+  "@vue/runtime-dom@3.2.47":
     dependencies:
-      '@vue/runtime-core': 3.2.47
-      '@vue/shared': 3.2.47
+      "@vue/runtime-core": 3.2.47
+      "@vue/shared": 3.2.47
       csstype: 2.6.21
 
-  '@vue/server-renderer@3.2.47(vue@3.2.47)':
+  "@vue/server-renderer@3.2.47(vue@3.2.47)":
     dependencies:
-      '@vue/compiler-ssr': 3.2.47
-      '@vue/shared': 3.2.47
+      "@vue/compiler-ssr": 3.2.47
+      "@vue/shared": 3.2.47
       vue: 3.2.47
 
-  '@vue/shared@3.2.47': {}
+  "@vue/shared@3.2.47": {}
 
-  '@vuepic/vue-datepicker@8.1.1(vue@3.2.47)':
+  "@vuepic/vue-datepicker@8.1.1(vue@3.2.47)":
     dependencies:
       date-fns: 3.3.1
       vue: 3.2.47
+
+  acorn-jsx@5.3.2(acorn@8.14.1):
+    dependencies:
+      acorn: 8.14.1
+
+  acorn@8.14.1: {}
+
+  ajv@6.12.6:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  argparse@2.0.1: {}
+
+  balanced-match@1.0.2: {}
+
+  boolbase@1.0.0: {}
+
+  brace-expansion@1.1.11:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  callsites@3.1.0: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  concat-map@0.0.1: {}
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  cssesc@3.0.0: {}
 
   csstype@2.6.21: {}
 
   date-fns@3.3.1: {}
 
+  debug@4.4.0:
+    dependencies:
+      ms: 2.1.3
+
+  deep-is@0.1.4: {}
+
   esbuild@0.16.17:
     optionalDependencies:
-      '@esbuild/android-arm': 0.16.17
-      '@esbuild/android-arm64': 0.16.17
-      '@esbuild/android-x64': 0.16.17
-      '@esbuild/darwin-arm64': 0.16.17
-      '@esbuild/darwin-x64': 0.16.17
-      '@esbuild/freebsd-arm64': 0.16.17
-      '@esbuild/freebsd-x64': 0.16.17
-      '@esbuild/linux-arm': 0.16.17
-      '@esbuild/linux-arm64': 0.16.17
-      '@esbuild/linux-ia32': 0.16.17
-      '@esbuild/linux-loong64': 0.16.17
-      '@esbuild/linux-mips64el': 0.16.17
-      '@esbuild/linux-ppc64': 0.16.17
-      '@esbuild/linux-riscv64': 0.16.17
-      '@esbuild/linux-s390x': 0.16.17
-      '@esbuild/linux-x64': 0.16.17
-      '@esbuild/netbsd-x64': 0.16.17
-      '@esbuild/openbsd-x64': 0.16.17
-      '@esbuild/sunos-x64': 0.16.17
-      '@esbuild/win32-arm64': 0.16.17
-      '@esbuild/win32-ia32': 0.16.17
-      '@esbuild/win32-x64': 0.16.17
+      "@esbuild/android-arm": 0.16.17
+      "@esbuild/android-arm64": 0.16.17
+      "@esbuild/android-x64": 0.16.17
+      "@esbuild/darwin-arm64": 0.16.17
+      "@esbuild/darwin-x64": 0.16.17
+      "@esbuild/freebsd-arm64": 0.16.17
+      "@esbuild/freebsd-x64": 0.16.17
+      "@esbuild/linux-arm": 0.16.17
+      "@esbuild/linux-arm64": 0.16.17
+      "@esbuild/linux-ia32": 0.16.17
+      "@esbuild/linux-loong64": 0.16.17
+      "@esbuild/linux-mips64el": 0.16.17
+      "@esbuild/linux-ppc64": 0.16.17
+      "@esbuild/linux-riscv64": 0.16.17
+      "@esbuild/linux-s390x": 0.16.17
+      "@esbuild/linux-x64": 0.16.17
+      "@esbuild/netbsd-x64": 0.16.17
+      "@esbuild/openbsd-x64": 0.16.17
+      "@esbuild/sunos-x64": 0.16.17
+      "@esbuild/win32-arm64": 0.16.17
+      "@esbuild/win32-ia32": 0.16.17
+      "@esbuild/win32-x64": 0.16.17
+
+  escape-string-regexp@4.0.0: {}
+
+  eslint-plugin-vue@10.0.0(eslint@9.22.0)(vue-eslint-parser@10.1.1(eslint@9.22.0)):
+    dependencies:
+      "@eslint-community/eslint-utils": 4.4.1(eslint@9.22.0)
+      eslint: 9.22.0
+      natural-compare: 1.4.0
+      nth-check: 2.1.1
+      postcss-selector-parser: 6.1.2
+      semver: 7.7.1
+      vue-eslint-parser: 10.1.1(eslint@9.22.0)
+      xml-name-validator: 4.0.0
+
+  eslint-scope@8.3.0:
+    dependencies:
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@4.2.0: {}
+
+  eslint@9.22.0:
+    dependencies:
+      "@eslint-community/eslint-utils": 4.4.1(eslint@9.22.0)
+      "@eslint-community/regexpp": 4.12.1
+      "@eslint/config-array": 0.19.2
+      "@eslint/config-helpers": 0.1.0
+      "@eslint/core": 0.12.0
+      "@eslint/eslintrc": 3.3.0
+      "@eslint/js": 9.22.0
+      "@eslint/plugin-kit": 0.2.7
+      "@humanfs/node": 0.16.6
+      "@humanwhocodes/module-importer": 1.0.1
+      "@humanwhocodes/retry": 0.4.2
+      "@types/estree": 1.0.6
+      "@types/json-schema": 7.0.15
+      ajv: 6.12.6
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.0
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.3.0
+      eslint-visitor-keys: 4.2.0
+      espree: 10.3.0
+      esquery: 1.6.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.2
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@10.3.0:
+    dependencies:
+      acorn: 8.14.1
+      acorn-jsx: 5.3.2(acorn@8.14.1)
+      eslint-visitor-keys: 4.2.0
+
+  esquery@1.6.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
 
   estree-walker@2.0.2: {}
+
+  esutils@2.0.3: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.3.3
+      keyv: 4.5.4
+
+  flatted@3.3.3: {}
 
   fsevents@2.3.2:
     optional: true
 
   function-bind@1.1.1: {}
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  globals@14.0.0: {}
+
+  globals@16.0.0: {}
+
+  has-flag@4.0.0: {}
 
   has@1.0.3:
     dependencies:
@@ -605,19 +1752,105 @@ snapshots:
       runes2: 1.1.4
       yup: 1.3.3
 
+  ignore@5.3.2: {}
+
+  import-fresh@3.3.1:
+    dependencies:
+      parent-module: 1.0.1
+      resolve-from: 4.0.0
+
+  imurmurhash@0.1.4: {}
+
   is-core-module@2.11.0:
     dependencies:
       has: 1.0.3
+
+  is-extglob@2.1.1: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  isexe@2.0.0: {}
+
+  js-yaml@4.1.0:
+    dependencies:
+      argparse: 2.0.1
+
+  json-buffer@3.0.1: {}
+
+  json-schema-traverse@0.4.1: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
+
+  lodash.merge@4.6.2: {}
+
+  lodash@4.17.21: {}
 
   magic-string@0.25.9:
     dependencies:
       sourcemap-codec: 1.4.8
 
+  minimatch@3.1.2:
+    dependencies:
+      brace-expansion: 1.1.11
+
+  ms@2.1.3: {}
+
   nanoid@3.3.4: {}
+
+  natural-compare@1.4.0: {}
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
+
+  parent-module@1.0.1:
+    dependencies:
+      callsites: 3.1.0
+
+  path-exists@4.0.0: {}
+
+  path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
 
   picocolors@1.0.0: {}
+
+  postcss-selector-parser@6.1.2:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss@8.4.18:
     dependencies:
@@ -631,16 +1864,24 @@ snapshots:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
+  prelude-ls@1.2.1: {}
+
+  prettier@3.5.3: {}
+
   primevue@4.2.4(vue@3.2.47):
     dependencies:
-      '@primeuix/styled': 0.3.2
-      '@primeuix/utils': 0.3.2
-      '@primevue/core': 4.2.4(vue@3.2.47)
-      '@primevue/icons': 4.2.4(vue@3.2.47)
+      "@primeuix/styled": 0.3.2
+      "@primeuix/utils": 0.3.2
+      "@primevue/core": 4.2.4(vue@3.2.47)
+      "@primevue/icons": 4.2.4(vue@3.2.47)
     transitivePeerDependencies:
       - vue
 
   property-expr@2.0.6: {}
+
+  punycode@2.3.1: {}
+
+  resolve-from@4.0.0: {}
 
   resolve@1.22.1:
     dependencies:
@@ -654,11 +1895,25 @@ snapshots:
 
   runes2@1.1.4: {}
 
+  semver@7.7.1: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   source-map-js@1.0.2: {}
 
   source-map@0.6.1: {}
 
   sourcemap-codec@1.4.8: {}
+
+  strip-json-comments@3.1.1: {}
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
@@ -668,7 +1923,17 @@ snapshots:
 
   toposort@2.0.2: {}
 
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
   type-fest@2.19.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
+
+  util-deprecate@1.0.2: {}
 
   vite@4.1.1:
     dependencies:
@@ -679,13 +1944,36 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
+  vue-eslint-parser@10.1.1(eslint@9.22.0):
+    dependencies:
+      debug: 4.4.0
+      eslint: 9.22.0
+      eslint-scope: 8.3.0
+      eslint-visitor-keys: 4.2.0
+      espree: 10.3.0
+      esquery: 1.6.0
+      lodash: 4.17.21
+      semver: 7.7.1
+    transitivePeerDependencies:
+      - supports-color
+
   vue@3.2.47:
     dependencies:
-      '@vue/compiler-dom': 3.2.47
-      '@vue/compiler-sfc': 3.2.47
-      '@vue/runtime-dom': 3.2.47
-      '@vue/server-renderer': 3.2.47(vue@3.2.47)
-      '@vue/shared': 3.2.47
+      "@vue/compiler-dom": 3.2.47
+      "@vue/compiler-sfc": 3.2.47
+      "@vue/runtime-dom": 3.2.47
+      "@vue/server-renderer": 3.2.47(vue@3.2.47)
+      "@vue/shared": 3.2.47
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  word-wrap@1.2.5: {}
+
+  xml-name-validator@4.0.0: {}
+
+  yocto-queue@0.1.0: {}
 
   yup@1.3.3:
     dependencies:

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,38 +1,38 @@
 <script setup>
-import DatePicker from 'primevue/datepicker';
-import '@vuepic/vue-datepicker/dist/main.css'
-import { ref } from 'vue';
-import * as ics from 'ics';
+import DatePicker from "primevue/datepicker";
+import "@vuepic/vue-datepicker/dist/main.css";
+import { ref } from "vue";
+import * as ics from "ics";
 
 const startDate = ref();
 const endDate = ref();
 
-const fileName = ref('上傳課表網頁檔案（html檔）');
+const fileName = ref("上傳課表網頁檔案（html檔）");
 const curriculumFile = ref();
 
 const scheduleTime = [
-  {"startTime" : "08:10", "endTime" : "09:00"},
-  {"startTime" : "09:10", "endTime" : "10:00"},
-  {"startTime" : "10:20", "endTime" : "11:10"},
-  {"startTime" : "11:20", "endTime" : "12:10"},
-  {"startTime" : "12:20", "endTime" : "13:10"},
-  {"startTime" : "13:20", "endTime" : "14:10"},
-  {"startTime" : "14:20", "endTime" : "15:10"},
-  {"startTime" : "15:30", "endTime" : "16:20"},
-  {"startTime" : "16:30", "endTime" : "17:20"},
-  {"startTime" : "17:30", "endTime" : "18:20"},
-  {"startTime" : "18:25", "endTime" : "19:15"},
-  {"startTime" : "19:20", "endTime" : "20:10"},
-  {"startTime" : "20:15", "endTime" : "21:05"},
-  {"startTime" : "21:10", "endTime" : "22:00"},
-]
+  { startTime: "08:10", endTime: "09:00" },
+  { startTime: "09:10", endTime: "10:00" },
+  { startTime: "10:20", endTime: "11:10" },
+  { startTime: "11:20", endTime: "12:10" },
+  { startTime: "12:20", endTime: "13:10" },
+  { startTime: "13:20", endTime: "14:10" },
+  { startTime: "14:20", endTime: "15:10" },
+  { startTime: "15:30", endTime: "16:20" },
+  { startTime: "16:30", endTime: "17:20" },
+  { startTime: "17:30", endTime: "18:20" },
+  { startTime: "18:25", endTime: "19:15" },
+  { startTime: "19:20", endTime: "20:10" },
+  { startTime: "20:15", endTime: "21:05" },
+  { startTime: "21:10", endTime: "22:00" },
+];
 
 function handleFileUpload(event) {
-  const file = event.target.files[0]; 
+  const file = event.target.files[0];
   if (file) {
-    fileName.value = '檔案上傳成功！'; 
+    fileName.value = "檔案上傳成功！";
   } else {
-    fileName.value = '上傳失敗，請重試。';
+    fileName.value = "上傳失敗，請重試。";
   }
 }
 
@@ -44,7 +44,7 @@ function parseCourses(htmlContent) {
   const courseRows = doc.querySelectorAll("table:nth-child(2) tbody tr");
 
   courseRows.forEach((row, index) => {
-    if (index > 0) { 
+    if (index > 0) {
       const cells = row.querySelectorAll("td");
       if (cells.length > 5) {
         const courseCode = cells[0].textContent.trim();
@@ -53,7 +53,13 @@ function parseCourses(htmlContent) {
         const courseType = cells[3].textContent.trim();
         const courseTeacher = cells[4].textContent.trim();
 
-        courses.push({ courseCode, courseName, courseCredits, courseType, courseTeacher });
+        courses.push({
+          courseCode,
+          courseName,
+          courseCredits,
+          courseType,
+          courseTeacher,
+        });
       }
     }
   });
@@ -65,29 +71,39 @@ function parseClassRoom(htmlContent) {
   const doc = parser.parseFromString(htmlContent, "text/html");
 
   let classRooms = {
-    '星期一' : [],
-    '星期二' : [],
-    '星期三' : [],
-    '星期四' : [],
-    '星期五' : [],
-    '星期六' : [],
-    '星期日' : [],
-  }
+    星期一: [],
+    星期二: [],
+    星期三: [],
+    星期四: [],
+    星期五: [],
+    星期六: [],
+    星期日: [],
+  };
   const curriculumRows = doc.querySelectorAll("table:nth-child(5) tbody tr");
 
   curriculumRows.forEach((row, index) => {
-    if (index > 0) { 
+    if (index > 0) {
       const cells = row.querySelectorAll("td");
       if (cells.length > 5) {
-        const days = ['星期一', '星期二', '星期三', '星期四', '星期五', '星期六', '星期日'];
+        const days = [
+          "星期一",
+          "星期二",
+          "星期三",
+          "星期四",
+          "星期五",
+          "星期六",
+          "星期日",
+        ];
         for (let i = 2; i < 9; i++) {
-
-          let courseClassRoom = '';
-          if ((cells[i].textContent.trim().length != 0) && cells[i].textContent.trim().includes('\n')) {
-            courseClassRoom = cells[i].textContent.trim().split('\n')[1].trim();
+          let courseClassRoom = "";
+          if (
+            cells[i].textContent.trim().length != 0 &&
+            cells[i].textContent.trim().includes("\n")
+          ) {
+            courseClassRoom = cells[i].textContent.trim().split("\n")[1].trim();
           }
 
-          classRooms[days[i-2]].push(courseClassRoom);
+          classRooms[days[i - 2]].push(courseClassRoom);
         }
       }
     }
@@ -100,66 +116,90 @@ function parseCurriculum(htmlContent) {
   const doc = parser.parseFromString(htmlContent, "text/html");
 
   let curriculum = {
-    '星期一' : [],
-    '星期二' : [],
-    '星期三' : [],
-    '星期四' : [],
-    '星期五' : [],
-    '星期六' : [],
-    '星期日' : [],
-  }
+    星期一: [],
+    星期二: [],
+    星期三: [],
+    星期四: [],
+    星期五: [],
+    星期六: [],
+    星期日: [],
+  };
   const curriculumRows = doc.querySelectorAll("table:nth-child(5) tbody tr");
   curriculumRows.forEach((row, index) => {
-    if (index > 0) { 
+    if (index > 0) {
       const cells = row.querySelectorAll("td");
       if (cells.length > 5) {
-        curriculum['星期一'].push(cells[2].textContent.trim().split('\n')[0].trim());
-        curriculum['星期二'].push(cells[3].textContent.trim().split('\n')[0].trim());
-        curriculum['星期三'].push(cells[4].textContent.trim().split('\n')[0].trim());
-        curriculum['星期四'].push(cells[5].textContent.trim().split('\n')[0].trim());
-        curriculum['星期五'].push(cells[6].textContent.trim().split('\n')[0].trim());
-        curriculum['星期六'].push(cells[7].textContent.trim().split('\n')[0].trim());
-        curriculum['星期日'].push(cells[8].textContent.trim().split('\n')[0].trim());
+        curriculum["星期一"].push(
+          cells[2].textContent.trim().split("\n")[0].trim(),
+        );
+        curriculum["星期二"].push(
+          cells[3].textContent.trim().split("\n")[0].trim(),
+        );
+        curriculum["星期三"].push(
+          cells[4].textContent.trim().split("\n")[0].trim(),
+        );
+        curriculum["星期四"].push(
+          cells[5].textContent.trim().split("\n")[0].trim(),
+        );
+        curriculum["星期五"].push(
+          cells[6].textContent.trim().split("\n")[0].trim(),
+        );
+        curriculum["星期六"].push(
+          cells[7].textContent.trim().split("\n")[0].trim(),
+        );
+        curriculum["星期日"].push(
+          cells[8].textContent.trim().split("\n")[0].trim(),
+        );
       }
     }
   });
   return curriculum;
 }
 
-function createEvents(courses,curriculum, classRooms) {
+function createEvents(courses, curriculum, classRooms) {
   let events = {
-    '星期一' : [],
-    '星期二' : [],
-    '星期三' : [],
-    '星期四' : [],
-    '星期五' : [],
-    '星期六' : [],
-    '星期日' : [],
-  }
+    星期一: [],
+    星期二: [],
+    星期三: [],
+    星期四: [],
+    星期五: [],
+    星期六: [],
+    星期日: [],
+  };
 
-  for(const [day, classes] of Object.entries(curriculum)) {
+  for (const [day, classes] of Object.entries(curriculum)) {
     let currentClassIndex = 0;
     let currentStartTime = scheduleTime[0].startTime;
     let currentEndTime = scheduleTime[0].endTime;
-    
+
     while (currentClassIndex < classes.length) {
-      
       // blank class
-      while (classes[currentClassIndex] == "" && currentClassIndex + 1 < classes.length) {
+      while (
+        classes[currentClassIndex] == "" &&
+        currentClassIndex + 1 < classes.length
+      ) {
         currentClassIndex++;
         currentStartTime = scheduleTime[currentClassIndex].startTime;
         currentEndTime = scheduleTime[currentClassIndex].endTime;
       }
-      if (currentClassIndex + 1 == classes.length && classes[currentClassIndex] == "") {
+      if (
+        currentClassIndex + 1 == classes.length &&
+        classes[currentClassIndex] == ""
+      ) {
         break;
       }
-      while (classes[currentClassIndex] == classes[currentClassIndex + 1] && currentClassIndex + 1 < classes.length) {
+      while (
+        classes[currentClassIndex] == classes[currentClassIndex + 1] &&
+        currentClassIndex + 1 < classes.length
+      ) {
         currentClassIndex++;
         currentEndTime = scheduleTime[currentClassIndex].endTime;
       }
-      const courseInfo = courses.find(c => c.courseName == classes[currentClassIndex]);
+      const courseInfo = courses.find(
+        (c) => c.courseName == classes[currentClassIndex],
+      );
       const classRoom = classRooms[day][currentClassIndex];
-      
+
       events[day].push({
         courseCode: courseInfo.courseCode,
         courseName: courseInfo.courseName,
@@ -180,27 +220,27 @@ function createEvents(courses,curriculum, classRooms) {
 
 function downloadFile() {
   if (!startDate.value || !endDate.value) {
-    alert('請選擇起始日期和結束日期！');
+    alert("請選擇起始日期和結束日期！");
     return;
   }
-  if(new Date(startDate.value) > new Date(endDate.value)) {
-    alert('結束日期需大於起始日期！');
+  if (new Date(startDate.value) > new Date(endDate.value)) {
+    alert("結束日期需大於起始日期！");
     return;
   }
   if (!curriculumFile.value || !curriculumFile.value.files[0]) {
-    alert('請上傳課表網頁檔案！');
+    alert("請上傳課表網頁檔案！");
     return;
   }
 
   const fileReader = new FileReader();
-  fileReader.onload = function(event) {
+  fileReader.onload = function (event) {
     const htmlContent = event.target.result;
 
     const courses = parseCourses(htmlContent);
-    const curriculum = parseCurriculum(htmlContent);    
+    const curriculum = parseCurriculum(htmlContent);
     const classRooms = parseClassRoom(htmlContent);
 
-    console.log(classRooms)
+    console.log(classRooms);
 
     const events = createEvents(courses, curriculum, classRooms);
 
@@ -209,28 +249,35 @@ function downloadFile() {
     let currentDate = new Date(startDate.value);
     while (currentDate <= new Date(endDate.value)) {
       const day = currentDate.getDay();
-      const dayString = ['星期日', '星期一', '星期二', '星期三', '星期四', '星期五', '星期六'][day];
-      events[dayString].forEach(event => {
+      const dayString = [
+        "星期日",
+        "星期一",
+        "星期二",
+        "星期三",
+        "星期四",
+        "星期五",
+        "星期六",
+      ][day];
+      events[dayString].forEach((event) => {
         const eventStartTime = new Date(currentDate);
-        eventStartTime.setHours(event.startTime.split(':')[0]);
-        eventStartTime.setMinutes(event.startTime.split(':')[1]);
+        eventStartTime.setHours(event.startTime.split(":")[0]);
+        eventStartTime.setMinutes(event.startTime.split(":")[1]);
 
         const eventEndTime = new Date(currentDate);
-        eventEndTime.setHours(event.endTime.split(':')[0]);
-        eventEndTime.setMinutes(event.endTime.split(':')[1]);
-
+        eventEndTime.setHours(event.endTime.split(":")[0]);
+        eventEndTime.setMinutes(event.endTime.split(":")[1]);
 
         icsEvents.push({
           start: eventStartTime.getTime(),
           end: eventEndTime.getTime(),
-          title: event['courseName'],
-          description: `導師：${event['courseTeacher']}\n課程代碼：${event['courseCode']}\n學分數：${event['courseCredits']}\n類型：${event['courseType']}`,
-          location: `臺科大 ${event['courseClassRoom']} 教室`,
-          status: 'CONFIRMED',
-          busyStatus: 'BUSY',
+          title: event["courseName"],
+          description: `導師：${event["courseTeacher"]}\n課程代碼：${event["courseCode"]}\n學分數：${event["courseCredits"]}\n類型：${event["courseType"]}`,
+          location: `臺科大 ${event["courseClassRoom"]} 教室`,
+          status: "CONFIRMED",
+          busyStatus: "BUSY",
         });
       });
-      
+
       currentDate.setDate(currentDate.getDate() + 1);
     }
     console.log(icsEvents);
@@ -240,11 +287,11 @@ function downloadFile() {
       return;
     }
     console.log(value);
-    const blob = new Blob([value], { type: 'text/calendar' });
+    const blob = new Blob([value], { type: "text/calendar" });
     const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
+    const a = document.createElement("a");
     a.href = url;
-    a.download = 'ntust_calendar.ics';
+    a.download = "ntust_calendar.ics";
     a.click();
   };
 
@@ -256,15 +303,39 @@ function downloadFile() {
   <img alt="Logo" src="./assets/ntust_so_hard.png" class="logo" />
   <h1 class="title">NTUST Calendar Maker</h1>
   <p>製作 .ics 檔案以匯入通用日曆軟體！</p>
-  <p><a href="https://github.com/Zudo-Developent/NTUST-Calendar-Maker">使用教學 | Github</a></p>
+  <p>
+    <a href="https://github.com/Zudo-Developent/NTUST-Calendar-Maker"
+      >使用教學 | Github</a
+    >
+  </p>
   <div class="datePickerContainer">
-    <DatePicker class="datePicker" v-model="startDate" placeholder="起始日期（開學）" showIcon fluid iconDisplay="input" />
-    <DatePicker class="datePicker" v-model="endDate" placeholder="結束日期（結業）" showIcon fluid iconDisplay="input" />
+    <DatePicker
+      class="datePicker"
+      v-model="startDate"
+      placeholder="起始日期（開學）"
+      showIcon
+      fluid
+      iconDisplay="input"
+    />
+    <DatePicker
+      class="datePicker"
+      v-model="endDate"
+      placeholder="結束日期（結業）"
+      showIcon
+      fluid
+      iconDisplay="input"
+    />
   </div>
-  
+
   <label class="fileUpload" for="curriculumFile">
     <span v-text="fileName"></span>
-    <input type="file" ref="curriculumFile" @change="handleFileUpload" id="curriculumFile" accept=".html"/>
+    <input
+      type="file"
+      ref="curriculumFile"
+      @change="handleFileUpload"
+      id="curriculumFile"
+      accept=".html"
+    />
   </label>
   <button id="buttonDownload" @click="downloadFile" raised>下載課表</button>
 </template>
@@ -276,43 +347,47 @@ function downloadFile() {
   padding: 1em;
 }
 
-
 .title {
   font-size: 2em;
-  font-weight: bold; 
-  text-align: center; 
-  background: linear-gradient(90deg, #d479d0, #a785eb); 
+  font-weight: bold;
+  text-align: center;
+  background: linear-gradient(90deg, #d479d0, #a785eb);
   background-clip: text;
-  -webkit-background-clip: text; 
-  -webkit-text-fill-color: transparent; 
-  text-shadow: 2px 4px 6px rgba(0, 0, 0, 0.3); 
-  margin: 0.5em 0; 
-  font-family: 'Poppins', sans-serif; 
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  text-shadow: 2px 4px 6px rgba(0, 0, 0, 0.3);
+  margin: 0.5em 0;
+  font-family: "Poppins", sans-serif;
 }
-
 
 #buttonDownload {
   margin: 1em;
   padding: 0.8em 2em;
-  font-size: 1.25em; 
-  border-radius: 0.5em; 
-  background: linear-gradient(135deg, #d15dcb, #8c52ff); 
+  font-size: 1.25em;
+  border-radius: 0.5em;
+  background: linear-gradient(135deg, #d15dcb, #8c52ff);
   color: white;
-  border: none; 
+  border: none;
   cursor: pointer;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 1px 3px rgba(0, 0, 0, 0.06); 
-  transition: all 0.3s ease; 
+  box-shadow:
+    0 4px 6px rgba(0, 0, 0, 0.1),
+    0 1px 3px rgba(0, 0, 0, 0.06);
+  transition: all 0.3s ease;
 }
 
 #buttonDownload:hover {
-  background: linear-gradient(135deg, #b84db6, #7345d6); 
-  transform: scale(1.05); 
-  box-shadow: 0 6px 8px rgba(0, 0, 0, 0.15), 0 2px 4px rgba(0, 0, 0, 0.1); 
+  background: linear-gradient(135deg, #b84db6, #7345d6);
+  transform: scale(1.05);
+  box-shadow:
+    0 6px 8px rgba(0, 0, 0, 0.15),
+    0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
 #buttonDownload:active {
-  transform: scale(0.98); 
-  box-shadow: 0 3px 5px rgba(0, 0, 0, 0.2), 0 1px 3px rgba(0, 0, 0, 0.1); 
+  transform: scale(0.98);
+  box-shadow:
+    0 3px 5px rgba(0, 0, 0, 0.2),
+    0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
 .logo {

--- a/src/main.js
+++ b/src/main.js
@@ -1,14 +1,14 @@
-import { createApp } from 'vue'
-import PrimeVue from 'primevue/config'
-import './style.css'
-import App from './App.vue'
+import { createApp } from "vue";
+import PrimeVue from "primevue/config";
+import "./style.css";
+import App from "./App.vue";
 
-import Aura from '@primevue/themes/aura';
+import Aura from "@primevue/themes/aura";
 
-const app = createApp(App)
+const app = createApp(App);
 app.use(PrimeVue, {
-    theme: {
-        preset: Aura
-    }
-})
-app.mount('#app')
+  theme: {
+    preset: Aura,
+  },
+});
+app.mount("#app");

--- a/src/style.css
+++ b/src/style.css
@@ -43,7 +43,7 @@ body {
 h1 {
   font-size: 3em;
   line-height: 1.1;
-  font-family:'Franklin Gothic Medium', 'Arial Narrow', Arial, sans-serif; 
+  font-family: "Franklin Gothic Medium", "Arial Narrow", Arial, sans-serif;
 }
 
 button {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
-import vue from '@vitejs/plugin-vue'
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [vue()],
-})
+});


### PR DESCRIPTION
## Description
This PR adds ESLint and Prettier configuration to ensure consistent code quality and formatting throughout the project.  

### 📁 Files & Configs
- `.eslintrc.json` – ESLint rules for Vue 3 + JavaScript setup
- `.prettierrc` – Prettier formatting rules
- Updated `package.json`:
  ```json
  "scripts": {
    "lint": "eslint . --ext .js,.vue",
    "format": "prettier --write .",
    "check": "npm run lint && npm run format"
  }
  ```

### Usage
- Run lint check:
  ```bash
  pnpm lint
  ```
- Auto-format code:
  ```bash
  pnpm format
  ```